### PR TITLE
Allow api_key to be empty

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -1,11 +1,7 @@
 
 # Get API key
 get_api_key <- function() {
-  api_key <- Sys.getenv("TCIA_API_KEY")
-  if(identical(api_key, "")) {
-    stop("Please request and store a valid API key (instructions: https://github.com/pamelarussell/TCIApathfinder)")
-  }
-  api_key
+  Sys.getenv("TCIA_API_KEY")
 }
 
 # The base URL and resource

--- a/README.Rmd
+++ b/README.Rmd
@@ -43,7 +43,8 @@ devtools::install_github("pamelarussell/TCIApathfinder")
 
 ## Authentication
 
-An API key is required to access data from TCIA. To obtain and correctly store your API key:
+An API key is not needed to access public collections on TCIA but it could be useful for private collections. 
+To obtain and correctly store your API key:
 
 1. Request a key from TCIA by following the instructions [here](https://wiki.cancerimagingarchive.net/display/Public/TCIA+Programmatic+Interface+%28REST+API%29+Usage+Guide).
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ devtools::install_github("pamelarussell/TCIApathfinder")
 
 ## Authentication
 
-An API key is required to access data from TCIA. To obtain and correctly
-store your API key:
+An API key is not needed to access public collections on TCIA but it could be useful for private collections. 
+To obtain and correctly store your API key:
 
 1.  Request a key from TCIA by following the instructions
     [here](https://wiki.cancerimagingarchive.net/display/Public/TCIA+Programmatic+Interface+%28REST+API%29+Usage+Guide).


### PR DESCRIPTION
The TCIA API no longer needs a key to access public collections.
However, this package produces an error if it detects an empty api key. 

This PR removes the key check, so now the package should work out of the box without any further configuration.
I'm assuming a valid api-key could still be used to access private collections, but I didn't test this.